### PR TITLE
fix: variables from dedicated env file should always take precedence

### DIFF
--- a/src/par_scrape/__main__.py
+++ b/src/par_scrape/__main__.py
@@ -64,9 +64,9 @@ if old_env_path.exists():
         old_env_path.rename(new_env_path)
 
 # Load the .env file from the project folder
-load_dotenv(dotenv_path=".env")
+load_dotenv(dotenv_path=".env", override=True)
 # Load the new .env file from the users home folder
-load_dotenv(dotenv_path=new_env_path)
+load_dotenv(dotenv_path=new_env_path, override=True)
 
 # Initialize Typer app
 app = typer.Typer(help="Web scraping tool with options for Selenium or Playwright")


### PR DESCRIPTION
This pull request updates the way environment variables are loaded in the main entry point of the `par_scrape` application. The most important change is ensuring that variables from the loaded `.env` files will override any existing environment variables, which helps prevent unexpected values from previous loads.

Environment variable loading:

* Updated both calls to `load_dotenv` in `src/par_scrape/__main__.py` to use `override=True`, ensuring that values from the `.env` files always take precedence over existing environment variables.